### PR TITLE
fix(gui_editor): キャラクターエディット画像選択をタイプ別サブフォルダに限定

### DIFF
--- a/documents/plan/018_gui_character_edit_fix.md
+++ b/documents/plan/018_gui_character_edit_fix.md
@@ -1,0 +1,8 @@
+# キャラクターエディット機能の改修
+
+- 画像の選択が現状
+    - assets/images/sprite/フォルダ内の画像全てに対してリスト化されている
+        - やりたいこと
+            - Faceは顔グラフィックなので　assets\images\sprite\faces の中身だけを選べるように
+            - Walkは歩行グラフィックなので　assets\images\sprite\actor の中身だけを選べるように
+            - Battleは戦闘グラフィックなので　assets\images\sprite\battle_actor の中身だけを選べるように

--- a/tools/gui_editor.py
+++ b/tools/gui_editor.py
@@ -2337,7 +2337,11 @@ class CharacterEditor(QScrollArea):
         super().__init__(parent)
         self._data = None
         self._updating = False
-        self._sprite_files = self._list_sprite_files()
+        self._sprite_files_by_type = {
+            "face": self._list_sprite_files("faces"),
+            "walk": self._list_sprite_files("actor"),
+            "battle": self._list_sprite_files("battle_actor"),
+        }
         self._graphic_widgets = {}
         self._base_stat_spins = {}
         self._growth_stat_spins = {}
@@ -2375,7 +2379,7 @@ class CharacterEditor(QScrollArea):
             row_layout.addWidget(QLabel(label + ":"))
             combo = QComboBox()
             combo.addItem("")
-            combo.addItems(self._sprite_files)
+            combo.addItems(self._sprite_files_by_type.get(graphic_type, []))
             combo.currentTextChanged.connect(self._on_changed)
             row_layout.addWidget(combo, 1)
             spin = QSpinBox()
@@ -2437,12 +2441,19 @@ class CharacterEditor(QScrollArea):
         layout.addWidget(magic_group)
         layout.addStretch()
 
-    def _list_sprite_files(self):
-        if not os.path.isdir(SPRITE_DIR):
+    _SPRITE_SUBDIR = {
+        "face": "faces",
+        "walk": "actor",
+        "battle": "battle_actor",
+    }
+
+    def _list_sprite_files(self, subdir):
+        target = os.path.join(SPRITE_DIR, subdir)
+        if not os.path.isdir(target):
             return []
         return sorted(
-            fname for fname in os.listdir(SPRITE_DIR)
-            if os.path.isfile(os.path.join(SPRITE_DIR, fname))
+            fname for fname in os.listdir(target)
+            if os.path.isfile(os.path.join(target, fname))
             and fname.lower().endswith((".png", ".jpg", ".jpeg", ".bmp"))
         )
 
@@ -2493,7 +2504,8 @@ class CharacterEditor(QScrollArea):
             preview.setPixmap(QPixmap())
             return
 
-        image_path = os.path.join(SPRITE_DIR, image_name)
+        subdir = self._SPRITE_SUBDIR.get(graphic_type, "")
+        image_path = os.path.join(SPRITE_DIR, subdir, image_name)
         image = QImage(image_path)
         if image.isNull():
             preview.setText("Load Error")


### PR DESCRIPTION
## Summary

- `CharacterEditor` の画像選択コンボボックスを、タイプ別サブフォルダに限定するよう修正
  - Face → `assets/images/sprite/faces/` のみ
  - Walk → `assets/images/sprite/actor/` のみ
  - Battle → `assets/images/sprite/battle_actor/` のみ
- `_list_sprite_files(subdir)` にサブディレクトリ引数を追加
- `_SPRITE_SUBDIR` クラス定数でタイプ→サブフォルダのマッピングを管理
- `_update_graphic_preview()` もサブフォルダを含むパスで画像を読み込むよう修正

## Test plan

- [ ] GUIエディタを起動してキャラクターエディタを開く
- [ ] Face コンボボックスに `faces/` 内のファイルのみ表示されること
- [ ] Walk コンボボックスに `actor/` 内のファイルのみ表示されること
- [ ] Battle コンボボックスに `battle_actor/` 内のファイルのみ表示されること
- [ ] 画像を選択するとプレビューが正常に表示されること

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)